### PR TITLE
bug fix for quick edit and for letting the card open for editing if the board link is invalid

### DIFF
--- a/src/nest.user.js
+++ b/src/nest.user.js
@@ -317,7 +317,7 @@
 
     addButtons();
 
-    if (!$target.is('.icon-edit') && !$target.parents(".icon-edit").length) {
+    if ($target.is('.icon-card') || $target.parents(".icon-card").length) {
       var target = getBoardFromCard(card);
       if (!target)
         return;

--- a/src/nest.user.js
+++ b/src/nest.user.js
@@ -317,27 +317,28 @@
 
     addButtons();
 
-    if ($target.is('.icon-edit') || $target.parents(".icon-edit").length) {
-
-      ignoreEvent = true;
-      $target.parents(".list-card").trigger('click');
-      ignoreEvent = false;
-    } else {
+    if (!$target.is('.icon-edit') && !$target.parents(".icon-edit").length) {
       var target = getBoardFromCard(card);
       if (!target) return;
+        return;
+      } 
       
       $.get(trelloAPI + target.type + "s/" + target.id + "?fields=url")
         .done(function (resp) {
           window.location.href = resp.url;
         })
         .fail(function (xhr, status, err) {
-          alert("Can't find target. The link might be broken or you might not have access to it.");
+          alert("Can't find target board. The board link might be broken or you might not have access to it.");
+          ignoreEvent = true;
+          $target.parents(".list-card").trigger('click');
+          ignoreEvent = false;
         });
-    }
 
-    e.preventDefault();
-    e.stopImmediatePropagation();
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
   }, true); // have to set useCapture because trello stops bubbling
+
 
   $(document).on("mouseenter", "#board .list-card", function () {
     var card = this;

--- a/src/nest.user.js
+++ b/src/nest.user.js
@@ -319,10 +319,9 @@
 
     if (!$target.is('.icon-edit') && !$target.parents(".icon-edit").length) {
       var target = getBoardFromCard(card);
-      if (!target) return;
+      if (!target)
         return;
-      } 
-      
+
       $.get(trelloAPI + target.type + "s/" + target.id + "?fields=url")
         .done(function (resp) {
           window.location.href = resp.url;


### PR DESCRIPTION
- fixed the issue with quick-edit button not working (before the fix the card would open up in full view instead of side menu)
- fixed the issue with inability to open the card for editing if the board link is incorrect + modified error message